### PR TITLE
Second part of pearl cost change

### DIFF
--- a/paper/src/main/java/com/devotedmc/ExilePearl/core/CoreExilePearl.java
+++ b/paper/src/main/java/com/devotedmc/ExilePearl/core/CoreExilePearl.java
@@ -582,6 +582,6 @@ final class CoreExilePearl implements ExilePearl {
     
 	  long sincePearled = System.currentTimeMillis() - getPearledOn().getTime();
 		double days = TimeUnit.MILLISECONDS.toDays(sincePearled);
-		return Math.max(1.0, Math.pow(1.25, (days / timer)));
+		return Math.max(1.0, Math.pow(1.2, (days / timer)));
 	}
 }


### PR DESCRIPTION
Second part of a two part change to make exile pearl costs scale more quickly overall. This specific change actually decreases how quickly the costs increase, while maintaining an interval of 21 days.