### PR TITLE
Show pearl locations in /ep showall if the pearl is being stored in a container

### DIFF
--- a/paper/src/main/java/com/devotedmc/ExilePearl/command/CmdShowAllPearls.java
+++ b/paper/src/main/java/com/devotedmc/ExilePearl/command/CmdShowAllPearls.java
@@ -26,6 +26,7 @@ import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
+import org.jetbrains.annotations.NotNull;
 import vg.civcraft.mc.civmodcore.CivModCorePlugin;
 import vg.civcraft.mc.civmodcore.chat.ChatUtils;
 import vg.civcraft.mc.civmodcore.inventory.gui.Clickable;
@@ -71,7 +72,7 @@ public class CmdShowAllPearls extends PearlCommand {
 				.sorted(ComparatorUtils.reversedComparator(Comparator.comparing(ExilePearl::getPearledOn)))
 				.<Supplier<IClickable>>map((pearl) -> () -> {
 					final boolean showLocation = pearl.getHolder().isBlock();
-					final Location pearlLocation = pearl.getLocation();
+					final Location pearlLocation = obscureLocationToNearestChunk(pearl.getLocation());
 					final boolean isPlayerBanned = isBanStickEnabled
 							&& BanHandler.isPlayerBanned(pearl.getPlayerId());
 
@@ -175,4 +176,16 @@ public class CmdShowAllPearls extends PearlCommand {
 		new MultiPageView(sender, lazyContents, "All Pearls", true).showScreen();
 	}
 
+	// TODO: This should probably be added to CivModCore
+	private static @NotNull Location obscureLocationToNearestChunk(
+			@NotNull Location location
+	) {
+		// This shaves off the last 16 off each axis: (6867, -31, 4237) will become (6864, -32, 4224)
+		// This means the location of obscured to the nearest chunk, and nearest vertical section
+		return location.clone().set(
+				location.getBlockX() & 0xFFFFFFF0,
+				location.getBlockY() & 0xFFFFFFF0,
+				location.getBlockZ() & 0xFFFFFFF0
+		);
+	}
 }


### PR DESCRIPTION
Pearl locations were added to `/ep showall` to give the playerbase some much needed transparency around pearls, but they were quickly neutered when the command was then spammed as it allowed players to track pearl movements in real time. This is still *technically* doable since a pearl's location is displayed if you're within 1.2x of its exclusion radius. What this PR does is undo the range limitation and instead impose a contextual container limitation: the location will only be shown if the pearl is contained within a block (a chest, barrel, etc), ie, live-tracking a pearl is no longer possible under *any* circumstance.


Also:
- Micro-optimised some of the component objects so they aren't re-allocated just to change their colour.
- Waypoint location uses the location known at time of `/ep showall` invocation, not at time of click (ie, allowing people to live-track pearls in real time by spam clicking the pearl).